### PR TITLE
Add navbar link testing script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+geckodriver.log

--- a/navbar_links/navbar_links.py
+++ b/navbar_links/navbar_links.py
@@ -1,0 +1,29 @@
+import os
+import time
+
+from dotenv import load_dotenv
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+
+load_dotenv()
+firefox_binary_path = os.environ.get("FIREFOX_BINARY_PATH")
+geckodriver_path = os.environ.get("GECKODRIVER_PATH")
+app_url = "https://staging.mindplex.ai/"
+
+driver = webdriver.Firefox(firefox_binary=firefox_binary_path, executable_path=geckodriver_path)
+driver.get(app_url)
+
+anchor_elements = driver.find_elements(By.CSS_SELECTOR, "a.header-links")
+anchor_hyperlinks = []
+for element in anchor_elements:
+    anchor_hyperlinks.append(element.get_attribute("href"))
+
+for hyperlink in anchor_hyperlinks:
+    driver.get(hyperlink)
+    time.sleep(2)
+    if driver.title:
+        print("Successfully opened: " + driver.title + " - " + hyperlink)
+    else:
+        print("Failed to open: " + hyperlink)
+
+driver.quit()


### PR DESCRIPTION
This PR adds a Python script that tests the links in the navbar of the web app. The script navigates to each link and verify that the page title is not empty. The script also prints a message for each link indicating whether it was successfully opened or not. 